### PR TITLE
Fix auth refresh timing and routing

### DIFF
--- a/Teachers/auth-refresh.js
+++ b/Teachers/auth-refresh.js
@@ -1,64 +1,93 @@
-// Detect custom domain and route to Netlify
-const getApiBase = () => {
-  const host = typeof window !== 'undefined' ? window.location.hostname : '';
-  if (host === 'willenaenglish.github.io' || host === 'willenaenglish.com' || host === 'www.willenaenglish.com') {
-    return 'https://willenaenglish.netlify.app';
-  }
-  return '';
-};
-const API_BASE = getApiBase();
-const REFRESH_ENDPOINT = `${API_BASE}/.netlify/functions/supabase_auth?action=refresh`;
-const REFRESH_INTERVAL = 1000 * 60 * 40; // 40 minutes
+// Shared teacher-session refresh helper.
+// Keeps the short-lived Supabase access token alive by using the long-lived
+// refresh-token cookie before the access token expires.
+
+const REFRESH_INTERVAL = 1000 * 60 * 35; // 35 minutes
+const MIN_FOCUS_REFRESH_AGE = 1000 * 60 * 15; // refresh after returning to an old tab
 
 let refreshTimer = null;
 let lastRefreshAt = 0;
 let refreshInFlight = null;
 
+async function refreshRequest() {
+  // Use the site's shared API router when it is available. It handles the
+  // current students domain, Cloudflare routing, credentials and local tokens.
+  if (window.WillenaAPI && typeof window.WillenaAPI.fetch === 'function') {
+    return window.WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=refresh&_=' + Date.now(), {
+      method: 'GET',
+      cache: 'no-store',
+    });
+  }
+
+  // Same-origin fallback for pages that load this module before api-config.js.
+  return fetch('/.netlify/functions/supabase_auth?action=refresh&_=' + Date.now(), {
+    method: 'GET',
+    credentials: 'include',
+    cache: 'no-store',
+  });
+}
+
 async function callRefresh() {
   if (refreshInFlight) return refreshInFlight;
+
   refreshInFlight = (async () => {
     try {
-      const resp = await fetch(REFRESH_ENDPOINT, { credentials: 'include' });
-      const json = await resp.json().catch(() => ({}));
-        if (!resp.ok || !(json && json.success)) {
-          console.debug('[auth-refresh] refresh request failed', { status: resp.status, body: json });
-        } else {
-          console.debug('[auth-refresh] refresh ok', { status: resp.status, body: json });
-        }
+      const response = await refreshRequest();
+      const data = await response.json().catch(() => ({}));
       lastRefreshAt = Date.now();
-      return json;
+
+      if (!response.ok || !data.success) {
+        console.debug('[auth-refresh] refresh did not succeed', {
+          status: response.status,
+          body: data,
+        });
+        return false;
+      }
+
+      console.debug('[auth-refresh] session refreshed');
+      try {
+        window.dispatchEvent(new CustomEvent('auth:refreshed'));
+      } catch {}
+      return true;
     } catch (error) {
+      lastRefreshAt = Date.now();
       console.debug('[auth-refresh] refresh request error', error);
-      return null;
+      return false;
     } finally {
       refreshInFlight = null;
     }
   })();
+
   return refreshInFlight;
 }
 
-export function ensureAuthRefresh() {
-  if (window.__authRefreshInitialized) {
-    return;
-  }
-  window.__authRefreshInitialized = true;
-
-  const schedule = () => {
-    if (refreshTimer) clearInterval(refreshTimer);
-    refreshTimer = setInterval(() => callRefresh(), REFRESH_INTERVAL);
-  };
-
-  callRefresh().then(schedule);
-
-  window.addEventListener('focus', () => {
-    const elapsed = Date.now() - lastRefreshAt;
-    if (elapsed > REFRESH_INTERVAL / 2) {
-      callRefresh();
-    }
-  });
+function scheduleRefresh() {
+  if (refreshTimer) clearInterval(refreshTimer);
+  refreshTimer = setInterval(callRefresh, REFRESH_INTERVAL);
 }
 
-// If the script is loaded outside of modules and we still want to trigger, expose global
+function refreshAfterReturning() {
+  if (document.visibilityState === 'hidden') return;
+  const elapsed = Date.now() - lastRefreshAt;
+  if (!lastRefreshAt || elapsed >= MIN_FOCUS_REFRESH_AGE) {
+    callRefresh();
+  }
+}
+
+export function ensureAuthRefresh() {
+  if (window.__authRefreshInitialized) return;
+  window.__authRefreshInitialized = true;
+
+  // Refresh immediately so an older-but-recoverable session is repaired as
+  // soon as the page loads, then continue before the access token expires.
+  callRefresh().finally(scheduleRefresh);
+
+  window.addEventListener('focus', refreshAfterReturning);
+  document.addEventListener('visibilitychange', refreshAfterReturning);
+  window.addEventListener('online', refreshAfterReturning);
+}
+
+// Preserve the existing global escape hatch for non-module callers.
 if (typeof window !== 'undefined') {
   window.ensureAuthRefresh = ensureAuthRefresh;
 }


### PR DESCRIPTION
This updates the shared teacher auth refresh helper to:

- refresh every 35 minutes instead of 40
- use `WillenaAPI.fetch()` so requests follow the current Cloudflare/students-domain routing
- refresh when the tab regains focus, becomes visible, or comes back online
- avoid overlapping refresh calls
- keep the existing global fallback for non-module callers

This is a low-risk first fix for the recurring ~45–60 minute logout. A follow-up may still be useful to make `whoami` automatically exchange the refresh token when the access token has already expired.