### PR TITLE
Add teacher-only server session repair

### DIFF
--- a/Teachers/auth-refresh.js
+++ b/Teachers/auth-refresh.js
@@ -1,57 +1,56 @@
-// Shared teacher-session refresh helper.
-// Keeps the short-lived Supabase access token alive by using the long-lived
-// refresh-token cookie before the access token expires.
+// Shared teacher-session repair helper.
+// Calls the teacher-only server action, which verifies the access token and
+// uses the refresh-token cookie when the access token has expired.
 
 const REFRESH_INTERVAL = 1000 * 60 * 35; // 35 minutes
-const MIN_FOCUS_REFRESH_AGE = 1000 * 60 * 15; // refresh after returning to an old tab
+const MIN_FOCUS_REFRESH_AGE = 1000 * 60 * 15;
 
 let refreshTimer = null;
 let lastRefreshAt = 0;
 let refreshInFlight = null;
 
-async function refreshRequest() {
-  // Use the site's shared API router when it is available. It handles the
-  // current students domain, Cloudflare routing, credentials and local tokens.
+async function sessionRequest() {
+  const path = '/.netlify/functions/supabase_auth?action=whoami_teacher&_=' + Date.now();
+
   if (window.WillenaAPI && typeof window.WillenaAPI.fetch === 'function') {
-    return window.WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=refresh&_=' + Date.now(), {
+    return window.WillenaAPI.fetch(path, {
       method: 'GET',
       cache: 'no-store',
     });
   }
 
-  // Same-origin fallback for pages that load this module before api-config.js.
-  return fetch('/.netlify/functions/supabase_auth?action=refresh&_=' + Date.now(), {
+  return fetch(path, {
     method: 'GET',
     credentials: 'include',
     cache: 'no-store',
   });
 }
 
-async function callRefresh() {
+async function repairSession() {
   if (refreshInFlight) return refreshInFlight;
 
   refreshInFlight = (async () => {
     try {
-      const response = await refreshRequest();
+      const response = await sessionRequest();
       const data = await response.json().catch(() => ({}));
       lastRefreshAt = Date.now();
 
       if (!response.ok || !data.success) {
-        console.debug('[auth-refresh] refresh did not succeed', {
+        console.debug('[auth-refresh] teacher session repair did not succeed', {
           status: response.status,
           body: data,
         });
         return false;
       }
 
-      console.debug('[auth-refresh] session refreshed');
+      console.debug('[auth-refresh] teacher session verified or repaired');
       try {
         window.dispatchEvent(new CustomEvent('auth:refreshed'));
       } catch {}
       return true;
     } catch (error) {
       lastRefreshAt = Date.now();
-      console.debug('[auth-refresh] refresh request error', error);
+      console.debug('[auth-refresh] teacher session request error', error);
       return false;
     } finally {
       refreshInFlight = null;
@@ -63,14 +62,14 @@ async function callRefresh() {
 
 function scheduleRefresh() {
   if (refreshTimer) clearInterval(refreshTimer);
-  refreshTimer = setInterval(callRefresh, REFRESH_INTERVAL);
+  refreshTimer = setInterval(repairSession, REFRESH_INTERVAL);
 }
 
-function refreshAfterReturning() {
+function repairAfterReturning() {
   if (document.visibilityState === 'hidden') return;
   const elapsed = Date.now() - lastRefreshAt;
   if (!lastRefreshAt || elapsed >= MIN_FOCUS_REFRESH_AGE) {
-    callRefresh();
+    repairSession();
   }
 }
 
@@ -78,16 +77,13 @@ export function ensureAuthRefresh() {
   if (window.__authRefreshInitialized) return;
   window.__authRefreshInitialized = true;
 
-  // Refresh immediately so an older-but-recoverable session is repaired as
-  // soon as the page loads, then continue before the access token expires.
-  callRefresh().finally(scheduleRefresh);
+  repairSession().finally(scheduleRefresh);
 
-  window.addEventListener('focus', refreshAfterReturning);
-  document.addEventListener('visibilitychange', refreshAfterReturning);
-  window.addEventListener('online', refreshAfterReturning);
+  window.addEventListener('focus', repairAfterReturning);
+  document.addEventListener('visibilitychange', repairAfterReturning);
+  window.addEventListener('online', repairAfterReturning);
 }
 
-// Preserve the existing global escape hatch for non-module callers.
 if (typeof window !== 'undefined') {
   window.ensureAuthRefresh = ensureAuthRefresh;
 }

--- a/cloudflare-workers/supabase-auth/src/teacher-index.js
+++ b/cloudflare-workers/supabase-auth/src/teacher-index.js
@@ -25,6 +25,24 @@ function sessionCookie(name, value) {
   return `${name}=${encodeURIComponent(value || '')}; Max-Age=${COOKIE_MAX_AGE}; Path=/; Domain=.willenaenglish.com; Secure; HttpOnly; SameSite=None`;
 }
 
+function jsonResponse(data, status, origin) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': origin || TEACHER_ORIGIN,
+      'Access-Control-Allow-Credentials': 'true',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+function asBaseWhoamiRequest(request) {
+  const url = new URL(request.url);
+  url.searchParams.set('action', 'whoami');
+  return new Request(url.toString(), request);
+}
+
 async function refreshTeacherSession(request, env, ctx) {
   const cookies = parseCookies(request.headers.get('Cookie') || '');
   const refreshToken = cookies.sb_refresh;
@@ -46,18 +64,20 @@ async function refreshTeacherSession(request, env, ctx) {
   if (!refreshResponse.ok || !session?.access_token) return null;
 
   const newRefreshToken = session.refresh_token || refreshToken;
-  const retryCookies = {
-    ...cookies,
-    sb_access: session.access_token,
-    sb_refresh: newRefreshToken,
-  };
-
   const retryHeaders = new Headers(request.headers);
-  retryHeaders.set('Cookie', serializeCookies(retryCookies));
+  retryHeaders.set(
+    'Cookie',
+    serializeCookies({
+      ...cookies,
+      sb_access: session.access_token,
+      sb_refresh: newRefreshToken,
+    })
+  );
 
-  const retryRequest = new Request(request, { headers: retryHeaders });
+  const retryRequest = asBaseWhoamiRequest(
+    new Request(request, { headers: retryHeaders })
+  );
   const retryResponse = await baseWorker.fetch(retryRequest, env, ctx);
-
   if (!retryResponse.ok) return null;
 
   const responseHeaders = new Headers(retryResponse.headers);
@@ -74,23 +94,33 @@ async function refreshTeacherSession(request, env, ctx) {
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
+    const action = url.searchParams.get('action');
+
+    // Every existing action remains delegated to the original worker unchanged.
+    if (action !== 'whoami_teacher') {
+      return baseWorker.fetch(request, env, ctx);
+    }
+
     const origin = request.headers.get('Origin') || '';
+    if (origin !== TEACHER_ORIGIN || request.method !== 'GET') {
+      return jsonResponse({ success: false, error: 'Action not found' }, 404, origin);
+    }
 
-    const response = await baseWorker.fetch(request, env, ctx);
+    const initialResponse = await baseWorker.fetch(
+      asBaseWhoamiRequest(request),
+      env,
+      ctx
+    );
 
-    const shouldRepairTeacherSession =
-      origin === TEACHER_ORIGIN &&
-      request.method === 'GET' &&
-      url.searchParams.get('action') === 'whoami' &&
-      response.status === 401;
-
-    if (!shouldRepairTeacherSession) return response;
+    if (initialResponse.status !== 401) return initialResponse;
 
     try {
-      return (await refreshTeacherSession(request, env, ctx)) || response;
+      return (
+        (await refreshTeacherSession(request, env, ctx)) || initialResponse
+      );
     } catch (error) {
       console.error('[teacher-whoami-refresh] Failed to repair session:', error);
-      return response;
+      return initialResponse;
     }
   },
 };

--- a/cloudflare-workers/supabase-auth/wrangler.toml
+++ b/cloudflare-workers/supabase-auth/wrangler.toml
@@ -1,5 +1,5 @@
 name = "supabase-auth"
-main = "src/index.js"
+main = "src/teacher-index.js"
 compatibility_date = "2024-01-01"
 
 # Required environment variables (set in Cloudflare Dashboard > Workers > Settings > Variables):


### PR DESCRIPTION
This PR targets the `teachers` branch and is intentionally isolated.

Changes:
- adds a new `whoami_teacher` action via a wrapper worker
- leaves every existing auth action delegated to the original worker unchanged
- restricts the new action to `https://teachers.willenaenglish.com`
- when the teacher access token is expired, exchanges the refresh token, rotates both cookies, and retries the original whoami check
- updates `Teachers/auth-refresh.js` to call only the new teacher action
- changes the worker entry point to the wrapper only within this branch

Nothing in this PR deploys the Cloudflare Worker automatically. The student branch and existing `whoami` action are untouched.