### PR TITLE
Keep teacher sessions alive across dashboard tools

### DIFF
--- a/Teachers/index.html
+++ b/Teachers/index.html
@@ -337,7 +337,7 @@
       (async function() {
         try {
           // Prefer cookie-based auth; do not depend on localStorage for access control.
-          const whoRes = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami&_=${Date.now()}`);
+          const whoRes = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami_teacher&_=${Date.now()}`);
           const who = await whoRes.json().catch(() => ({}));
           if (!who || !who.success || !who.user_id) {
             const redirect = encodeURIComponent(location.pathname + location.search);
@@ -462,7 +462,7 @@
         let name = '';
         let userId = '';
         try {
-          const whoRes = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami&_=${Date.now()}`);
+          const whoRes = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami_teacher&_=${Date.now()}`);
           const who = await whoRes.json().catch(() => ({}));
           if (who && who.success && who.user_id) {
             userId = who.user_id;

--- a/Teachers/tools/manage_students.js
+++ b/Teachers/tools/manage_students.js
@@ -1555,7 +1555,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   wire();
   // auth guard: ensure teacher role
   try {
-    const who = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami').then(r=>r.json());
+    const who = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami_teacher').then(r=>r.json());
     if (!who?.success) throw new Error('not signed in');
     const roleRes = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=get_role&user_id=${encodeURIComponent(who.user_id)}`);
     const role = await roleRes.json();

--- a/Teachers/tools/student_tracker/main.js
+++ b/Teachers/tools/student_tracker/main.js
@@ -5,8 +5,8 @@ const userRoleReady = new Promise((resolve) => { userRoleReadyResolve = resolve;
 (async function() {
   try {
     const who = await (window.WillenaAPI
-      ? window.WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami')
-      : fetch('/.netlify/functions/supabase_auth?action=whoami', { credentials: 'include' }));
+      ? window.WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami_teacher')
+      : fetch('/.netlify/functions/supabase_auth?action=whoami_teacher', { credentials: 'include' }));
     const whoJson = await who.json().catch(() => ({}));
     if (!who.ok || !whoJson?.success || !whoJson?.user_id) {
       const redirect = encodeURIComponent(location.pathname + location.search);

--- a/components/burger-menu.js
+++ b/components/burger-menu.js
@@ -1,3 +1,11 @@
+// Teacher-only session repair bootstrap.
+// This shared component is loaded by the teacher dashboard and most teacher tools.
+if (typeof window !== 'undefined' && window.location.hostname === 'teachers.willenaenglish.com') {
+  import('/Teachers/auth-refresh.js?v=20260726b')
+    .then((mod) => mod.ensureAuthRefresh())
+    .catch((error) => console.debug('[teacher-session] bootstrap failed', error));
+}
+
 // Burger menu component loader
 // Usage: import this file and call insertBurgerMenu() after DOMContentLoaded
 


### PR DESCRIPTION
Teacher-only session coverage fix.

Changes:
- starts the existing teacher session-repair helper from the shared burger-menu module on teachers.willenaenglish.com
- switches the dashboard, Student Tracker, and Student Manager initial auth gates to whoami_teacher
- leaves student pages untouched
- keeps all existing redirect behaviour when session repair genuinely fails

Rollback branch: teacher-shared-session-repair