### PR TITLE
Keep student sessions alive across apps

### DIFF
--- a/Games/english_arcade/index.html
+++ b/Games/english_arcade/index.html
@@ -162,7 +162,7 @@
           return;
         }
         // Fetch whoami quickly; if unauthorized, redirect before heavy scripts load
-        WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami')
+        WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami_student')
           .then(r => r.ok ? r.json() : null)
           .then(js => { if (!js || !js.success || !js.user_id) goLogin(); })
           .catch(() => goLogin());
@@ -295,7 +295,7 @@
       async function getCurrentUserIdCached() {
         if (currentUserIdCache) return currentUserIdCache;
         try {
-          const whoRes = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami');
+          const whoRes = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami_student');
           const whoJson = await whoRes.json().catch(() => ({}));
           if (whoRes.ok && whoJson.success && whoJson.user_id) {
             currentUserIdCache = whoJson.user_id;
@@ -515,7 +515,7 @@
               console.log(`[HW Badge] assignment ${a.id} (${a.title}):`, { _v: pj._v, is_spelling_only: pj.is_spelling_only, _debug_meta: pj._debug_meta, localSpellingOnly, badgeForcedMode, badgeModesTotal });
               if (pr.ok && pj && pj.success && Array.isArray(pj.progress)) {
                 // find current user row if present
-                const who = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami').then(r=>r.ok?r.json():{}).catch(()=>({}));
+                const who = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami_student').then(r=>r.ok?r.json():{}).catch(()=>({}));
                 const uid = who && who.user_id ? who.user_id : null;
                 let myRow = null;
                 if (uid) myRow = pj.progress.find(p => String(p.user_id) === String(uid));
@@ -582,7 +582,7 @@
           // Determine current student user_id first (needed to match progress rows)
             let currentUserId = null;
             try {
-              const whoRes = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami');
+              const whoRes = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami_student');
               const whoJson = await whoRes.json().catch(()=>({}));
               if (whoRes.ok && whoJson.success && whoJson.user_id) currentUserId = whoJson.user_id;
             } catch {}

--- a/Games/english_arcade/play.html
+++ b/Games/english_arcade/play.html
@@ -33,7 +33,7 @@
 	    }
 	    if (hasGuest) { window.__AUTH_OK = true; show(); return; }
 	    try {
-	      const r = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami');
+	      const r = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami_student');
 	      if(r.ok){ const d=await r.json().catch(()=>null); if(d&&d.success){ window.__AUTH_OK=true; show(); return; } }
 	    } catch {}
 	    const next = encodeURIComponent(location.pathname + location.search);

--- a/students/auth-refresh.js
+++ b/students/auth-refresh.js
@@ -1,0 +1,79 @@
+// Shared student-session repair helper.
+// Verifies the current access token and uses the refresh-token cookie when needed.
+
+const REFRESH_INTERVAL = 1000 * 60 * 35;
+const MIN_FOCUS_REFRESH_AGE = 1000 * 60 * 15;
+
+let refreshTimer = null;
+let lastRefreshAt = 0;
+let refreshInFlight = null;
+
+async function sessionRequest() {
+  const path = '/.netlify/functions/supabase_auth?action=whoami_student&_=' + Date.now();
+
+  if (window.WillenaAPI && typeof window.WillenaAPI.fetch === 'function') {
+    return window.WillenaAPI.fetch(path, { method: 'GET', cache: 'no-store' });
+  }
+
+  return fetch(path, {
+    method: 'GET',
+    credentials: 'include',
+    cache: 'no-store',
+  });
+}
+
+async function repairSession() {
+  if (refreshInFlight) return refreshInFlight;
+
+  refreshInFlight = (async () => {
+    try {
+      const response = await sessionRequest();
+      const data = await response.json().catch(() => ({}));
+      lastRefreshAt = Date.now();
+
+      if (!response.ok || !data.success) {
+        console.debug('[student-auth-refresh] session repair did not succeed', {
+          status: response.status,
+          body: data,
+        });
+        return false;
+      }
+
+      try { window.dispatchEvent(new CustomEvent('auth:refreshed')); } catch {}
+      return true;
+    } catch (error) {
+      lastRefreshAt = Date.now();
+      console.debug('[student-auth-refresh] request error', error);
+      return false;
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+
+  return refreshInFlight;
+}
+
+function scheduleRefresh() {
+  if (refreshTimer) clearInterval(refreshTimer);
+  refreshTimer = setInterval(repairSession, REFRESH_INTERVAL);
+}
+
+function repairAfterReturning() {
+  if (document.visibilityState === 'hidden') return;
+  const elapsed = Date.now() - lastRefreshAt;
+  if (!lastRefreshAt || elapsed >= MIN_FOCUS_REFRESH_AGE) repairSession();
+}
+
+export function ensureStudentAuthRefresh() {
+  if (window.__studentAuthRefreshInitialized) return;
+  window.__studentAuthRefreshInitialized = true;
+
+  repairSession().finally(scheduleRefresh);
+  window.addEventListener('focus', repairAfterReturning);
+  document.addEventListener('visibilitychange', repairAfterReturning);
+  window.addEventListener('online', repairAfterReturning);
+}
+
+if (typeof window !== 'undefined') {
+  window.ensureStudentAuthRefresh = ensureStudentAuthRefresh;
+}

--- a/students/components/student-header.js
+++ b/students/components/student-header.js
@@ -1,3 +1,10 @@
+// Student session repair bootstrap.
+if (typeof window !== 'undefined' && window.location.hostname === 'students.willenaenglish.com') {
+  import('/students/auth-refresh.js?v=20260726a')
+    .then((mod) => mod.ensureStudentAuthRefresh())
+    .catch((error) => console.debug('[student-session] bootstrap failed', error));
+}
+
 // Reusable Student Header Web Component
 // Usage: <student-header home-href="/index.html" home-label="Home"></student-header>
 const WA_AUDIO_SOUND_KEY = 'wa.audio.sound.enabled';
@@ -253,7 +260,7 @@ class StudentHeader extends HTMLElement {
 
   async _hydrateProfile() {
     try {
-      const whoRes = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami&_=${Date.now()}`);
+      const whoRes = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami_student&_=${Date.now()}`);
       const who = await whoRes.json();
       if (!who || !who.success || !who.user_id) return;
       this._uid = who.user_id;
@@ -392,7 +399,7 @@ class StudentHeader extends HTMLElement {
             let uid = this._uid || null;
             if (!uid) {
               try {
-                const who = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami&_=${Date.now()}`);
+                const who = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami_student&_=${Date.now()}`);
                 if (who.ok) {
                   const wj = await who.json().catch(() => ({}));
                   if (wj && wj.success && wj.user_id) uid = wj.user_id;

--- a/students/dashboard.html
+++ b/students/dashboard.html
@@ -68,7 +68,7 @@
           return; // stop further checks to avoid lots of 401s
         }
 
-        const who = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami&_=${Date.now()}`);
+        const who = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami_student&_=${Date.now()}`);
         console.log('[Dashboard] Auth check response:', who.status, who.statusText);
         const w = await who.json();
         console.log('[Dashboard] Auth data:', w);
@@ -742,7 +742,7 @@
         // Determine current student user_id first so we can match progress rows
         let currentUserId = null;
         try {
-          const whoRes = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami&_=${Date.now()}`);
+          const whoRes = await WillenaAPI.fetch(`/.netlify/functions/supabase_auth?action=whoami_student&_=${Date.now()}`);
           const whoJson = await whoRes.json().catch(()=>({}));
           if (whoRes.ok && whoJson.success && whoJson.user_id) currentUserId = whoJson.user_id;
         } catch {}

--- a/students/profile.html
+++ b/students/profile.html
@@ -23,7 +23,7 @@
     async function getProfileInfo() {
       try {
         // Get user id from cookie session
-        const who = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami');
+        const who = await WillenaAPI.fetch('/.netlify/functions/supabase_auth?action=whoami_student');
         const whoRes = await who.json();
         if (!whoRes.success || !whoRes.user_id) {
           // For cross-origin scenarios, if whoami fails, redirect to Netlify version


### PR DESCRIPTION
Student session coverage update.

Changes:
- adds a shared student auth repair helper
- starts it from the shared student-header component
- switches the student dashboard, profile, English Arcade landing page, and live play gate to whoami_student
- leaves teacher pages untouched
- preserves guest access in live play mode

This PR should only merge after the Worker with whoami_student deploys successfully.