### PR TITLE
Use student session repair in records tracker

### DIFF
--- a/students/records.js
+++ b/students/records.js
@@ -57,7 +57,7 @@ let __lastAuthRefresh = 0;
 
 async function fetchWhoAmI() {
   try {
-  const res = await fetch(FN('supabase_auth') + '?action=whoami', {
+  const res = await fetch(FN('supabase_auth') + '?action=whoami_student', {
       credentials: 'include',
       cache: 'no-store'
     });


### PR DESCRIPTION
Updates the shared student scoring/activity tracker to resolve identity through whoami_student instead of the legacy whoami route. This keeps point and session logging aligned with the new student refresh-token repair path. No scoring rules or retry behaviour are changed.