### PR TITLE
Make Word Builder responsive on mobile

### DIFF
--- a/Teachers/tools/wordtest/styles/responsive.css
+++ b/Teachers/tools/wordtest/styles/responsive.css
@@ -1,10 +1,250 @@
 /* Responsive adjustments for smaller screens */
-@media (max-width: 1200px) {
+@media (max-width: 1200px) and (min-width: 901px) {
   .preview-area { min-width: 800px; }
   .worksheet-preview table { min-width: 750px; }
 }
 
+/* Phone and narrow tablet layout. Desktop styles above this breakpoint are untouched. */
 @media (max-width: 900px) {
-  .preview-area { min-width: 700px; }
-  .worksheet-preview table { min-width: 650px; }
+  html,
+  body {
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
+  .container {
+    max-width: 100%;
+    width: 100%;
+    padding: 8px;
+    box-sizing: border-box;
+  }
+
+  .app-card {
+    width: 100%;
+    border-radius: 10px;
+  }
+
+  .header {
+    min-height: 48px;
+  }
+
+  .logo-img {
+    height: 40px;
+  }
+
+  .header h1 {
+    font-size: 1.1rem;
+  }
+
+  .top-actions {
+    position: relative;
+    top: auto;
+    gap: 4px;
+    padding: 4px 8px;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+  }
+
+  .top-actions .action-link {
+    flex: 0 0 auto;
+    padding: 6px 8px;
+    font-size: 13px;
+    white-space: nowrap;
+  }
+
+  #moreBtn {
+    margin-left: 0;
+    left: 0 !important;
+  }
+
+  #burger-menu-mount {
+    position: static;
+    transform: none;
+    flex: 0 0 auto;
+    margin-right: 0 !important;
+  }
+
+  .floating-toolbar {
+    position: relative;
+    top: auto;
+    gap: 8px;
+    padding: 8px;
+    align-items: stretch;
+  }
+
+  .floating-toolbar > * {
+    max-width: 100%;
+  }
+
+  .toolbar-select,
+  .layout-select,
+  .test-mode-select,
+  .picture-mode-select {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .layout-group,
+  .slider-group {
+    flex: 1 1 145px;
+    min-width: 0;
+  }
+
+  .layout-group .layout-select {
+    width: 100%;
+  }
+
+  .slider-group .slider {
+    min-width: 70px;
+    width: 100%;
+  }
+
+  .main-content {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    width: 100%;
+  }
+
+  .sidebar {
+    width: 100%;
+    padding: 16px;
+    border-right: 0;
+    border-bottom: 1px solid #e1e8ed;
+    box-sizing: border-box;
+  }
+
+  .button-group > button {
+    flex: 1 1 0;
+  }
+
+  .preview-area {
+    display: block;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    padding: 12px 6px;
+    box-sizing: border-box;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .worksheet-preview {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+
+  /* Basic word lists fit the phone instead of forcing a desktop-width page. */
+  .worksheet-preview table {
+    width: 100% !important;
+    min-width: 0;
+    table-layout: fixed;
+  }
+
+  .worksheet-preview table[style*="width:100%"] {
+    min-width: 0;
+  }
+
+  .worksheet-preview table th,
+  .worksheet-preview table td {
+    padding: 9px 4px;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .worksheet-preview table colgroup col,
+  .worksheet-preview table td[style*="text-align:center"] {
+    min-width: 0;
+  }
+
+  /* Layouts that genuinely need width scroll inside the preview, not the whole page. */
+  .worksheet-preview .matching-container,
+  .worksheet-preview .eng-kor-matching,
+  .worksheet-preview .image-grid,
+  .picture-matching-grid {
+    min-width: 650px;
+  }
+
+  /* Manual Mobile mode also works on wider foldable/tablet viewports. */
+  body[data-wordtest-layout="mobile"] .main-content {
+    flex-direction: column;
+  }
+}
+
+/* Explicit Mobile mode can be selected on a wide Fold/tablet without changing desktop defaults. */
+body[data-wordtest-layout="mobile"] .main-content {
+  flex-direction: column;
+}
+
+body[data-wordtest-layout="mobile"] .sidebar {
+  width: 100%;
+  border-right: 0;
+  border-bottom: 1px solid #e1e8ed;
+  box-sizing: border-box;
+}
+
+body[data-wordtest-layout="mobile"] .preview-area {
+  width: 100%;
+  min-width: 0;
+  max-width: none;
+  box-sizing: border-box;
+  overflow-x: auto;
+}
+
+/* Explicit Desktop mode preserves the original wide canvas on a phone. */
+@media screen {
+  body[data-wordtest-layout="desktop"] {
+    min-width: 1280px;
+    overflow-x: auto;
+  }
+
+  body[data-wordtest-layout="desktop"] .container {
+    max-width: 97vw;
+    width: auto;
+    padding: 20px;
+  }
+
+  body[data-wordtest-layout="desktop"] .main-content {
+    flex-direction: row;
+    min-height: 600px;
+  }
+
+  body[data-wordtest-layout="desktop"] .sidebar {
+    width: 320px;
+    flex: 0 0 320px;
+    padding: 24px;
+    border-right: 1px solid #e1e8ed;
+    border-bottom: 0;
+  }
+
+  body[data-wordtest-layout="desktop"] .preview-area {
+    min-width: 900px;
+    max-width: 1200px;
+    padding: 32px;
+    overflow: visible;
+  }
+
+  body[data-wordtest-layout="desktop"] .worksheet-preview table {
+    min-width: 800px;
+  }
+
+  body[data-wordtest-layout="desktop"] .worksheet-preview table[style*="width:100%"] {
+    min-width: 850px;
+  }
+}
+
+/* Small layout selector injected by wordtest.js */
+.wordtest-view-select {
+  background: #fff;
+  border: 1px solid #cbd5e0;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 13px;
+  color: #374151;
+  cursor: pointer;
+  max-width: 150px;
 }

--- a/Teachers/tools/wordtest/wordtest.js
+++ b/Teachers/tools/wordtest/wordtest.js
@@ -17,5 +17,51 @@ window.generatePDF = generatePDF;
 window.updatePreview = updatePreview;
 window.updateWordtestPreview = updatePreview;
 
+const VIEW_STORAGE_KEY = 'wordtest-view-mode';
+
+function applyViewMode(mode) {
+  const validMode = ['auto', 'mobile', 'desktop'].includes(mode) ? mode : 'auto';
+  if (validMode === 'auto') {
+    document.body.removeAttribute('data-wordtest-layout');
+  } else {
+    document.body.setAttribute('data-wordtest-layout', validMode);
+  }
+  return validMode;
+}
+
+function setupViewSelector() {
+  const toolbar = document.querySelector('.floating-toolbar');
+  if (!toolbar || document.getElementById('wordtestViewSelect')) return;
+
+  let savedMode = 'auto';
+  try {
+    savedMode = localStorage.getItem(VIEW_STORAGE_KEY) || 'auto';
+  } catch (_) {}
+  savedMode = applyViewMode(savedMode);
+
+  const select = document.createElement('select');
+  select.id = 'wordtestViewSelect';
+  select.className = 'wordtest-view-select';
+  select.title = 'Choose how this page is laid out on this device';
+  select.setAttribute('aria-label', 'Page view');
+  select.innerHTML = `
+    <option value="auto">View: Auto</option>
+    <option value="mobile">View: Mobile</option>
+    <option value="desktop">View: Desktop</option>
+  `;
+  select.value = savedMode;
+
+  select.addEventListener('change', () => {
+    const mode = applyViewMode(select.value);
+    try {
+      localStorage.setItem(VIEW_STORAGE_KEY, mode);
+    } catch (_) {}
+    window.scrollTo({ left: 0, behavior: 'smooth' });
+  });
+
+  toolbar.appendChild(select);
+}
+
 // Bootstrap
 initWordtest();
+setupViewSelector();


### PR DESCRIPTION
Adds a phone-friendly stacked layout while leaving the existing desktop layout unchanged.

Also adds a persistent View selector with Auto, Mobile and Desktop options. Wide worksheet formats scroll inside the preview instead of breaking the entire page.