### PR TITLE
Refresh student header after session repair

### DIFF
--- a/students/auth-refresh.js
+++ b/students/auth-refresh.js
@@ -39,7 +39,11 @@ async function repairSession() {
         return false;
       }
 
+      // Keep both event names for compatibility. The shared header already
+      // listens for auth:changed and will immediately reload identity,
+      // points, and stars after a successful session repair.
       try { window.dispatchEvent(new CustomEvent('auth:refreshed')); } catch {}
+      try { window.dispatchEvent(new CustomEvent('auth:changed')); } catch {}
       return true;
     } catch (error) {
       lastRefreshAt = Date.now();


### PR DESCRIPTION
After whoami_student successfully repairs a student session, emit the existing auth:changed event so the shared student header immediately reloads identity, points, and stars. This is a one-file compatibility fix; scoring and auth rules are unchanged.