### PR TITLE
Paginate matching worksheets without dropping words

### DIFF
--- a/Teachers/tools/wordtest/matching-renderer.js
+++ b/Teachers/tools/wordtest/matching-renderer.js
@@ -1,0 +1,133 @@
+// Paginated matching layouts for Word Builder.
+// Kept separate so the feature is easy to disable or roll back.
+
+function chunk(items, size) {
+  const pages = [];
+  for (let i = 0; i < items.length; i += size) pages.push(items.slice(i, i + size));
+  return pages;
+}
+
+function shuffled(items) {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+function pageCss() {
+  return `<style>
+    .matching-pages { display:flex; flex-direction:column; gap:24px; align-items:center; }
+    .matching-page {
+      width:210mm;
+      min-height:297mm;
+      box-sizing:border-box;
+      padding:12.7mm;
+      background:#fff;
+      box-shadow:0 4px 18px rgba(0,0,0,.12);
+      break-after:page;
+      page-break-after:always;
+      overflow:hidden;
+    }
+    .matching-page:last-child { break-after:auto; page-break-after:auto; }
+    .matching-page-label { text-align:right; color:#718096; font-size:11px; margin-top:-2px; margin-bottom:8px; }
+    .matching-board { display:flex; justify-content:space-between; align-items:flex-start; width:100%; margin:0 auto; }
+    .matching-column { display:flex; flex-direction:column; }
+    .matching-row { display:flex; align-items:center; }
+    .matching-dot { width:14px; height:14px; border:3px solid #333; border-radius:50%; background:#fff; flex:0 0 auto; }
+    .matching-card { border:2px solid #e2e8f0; border-radius:8px; box-shadow:0 1px 3px rgba(0,0,0,.08); display:flex; align-items:center; flex:1; }
+    .matching-centre { display:flex; align-items:center; justify-content:center; color:#b8c0cc; font-size:13px; text-align:center; font-style:italic; }
+    @media screen and (max-width:900px) {
+      .matching-pages { align-items:flex-start; gap:14px; }
+      .matching-page { transform-origin:top left; box-shadow:none; }
+    }
+    @media print {
+      .matching-pages { display:block; }
+      .matching-page { width:100%; min-height:0; padding:0; margin:0; box-shadow:none; overflow:visible; }
+      .matching-page-label { color:#666; }
+    }
+  </style>`;
+}
+
+async function renderPicturePage(pagePairs, pageIndex, pageCount, settings, renderImage, getImageUrl, generateHeader, title, globalOffset) {
+  const withImages = await Promise.all(pagePairs.map(async (pair, localIndex) => {
+    const globalIndex = globalOffset + localIndex;
+    const imageUrl = await getImageUrl(pair._originalEng || pair.eng, globalIndex, false, settings);
+    return { ...pair, imageUrl, globalIndex };
+  }));
+  const words = shuffled(withImages);
+  const gap = Math.max(6, Math.min(settings.imageGap || 10, 18));
+  const itemHeight = Math.max((settings.imageSize || 70) + 12, 70);
+  const totalHeight = withImages.length * itemHeight + Math.max(0, withImages.length - 1) * gap;
+
+  return `<section class="matching-page picture-matching-page">
+    ${await generateHeader(title)}
+    <div class="matching-page-label">Page ${pageIndex + 1} of ${pageCount}</div>
+    <div class="matching-board" style="min-width:700px;">
+      <div class="matching-column" style="width:36%;min-height:${totalHeight}px;gap:${gap}px;">
+        ${withImages.map(pair => `<div class="matching-row" style="justify-content:flex-end;gap:12px;height:${itemHeight}px;">
+          <div class="image-container" style="display:flex;align-items:center;position:relative;">${renderImage(pair.imageUrl, pair.globalIndex, pair._originalEng || pair.eng, pair.kor, settings)}</div>
+          <div class="matching-dot"></div>
+        </div>`).join('')}
+      </div>
+      <div class="matching-centre" style="width:26%;min-height:${totalHeight}px;">Draw lines<br>to connect</div>
+      <div class="matching-column" style="width:38%;min-height:${totalHeight}px;gap:${gap}px;">
+        ${words.map(pair => `<div class="matching-row" style="justify-content:flex-start;gap:12px;height:${itemHeight}px;">
+          <div class="matching-dot"></div>
+          <div class="matching-card word-cell" data-index="${pair.globalIndex}" data-lang="eng" style="padding:10px 14px;background:#f8f9fa;font-weight:600;cursor:pointer;">${pair.eng || '______'}</div>
+        </div>`).join('')}
+      </div>
+    </div>
+  </section>`;
+}
+
+async function renderLanguagePage(pagePairs, pageIndex, pageCount, settings, generateHeader, title, globalOffset) {
+  const indexed = pagePairs.map((pair, localIndex) => ({ ...pair, globalIndex: globalOffset + localIndex }));
+  const korean = shuffled(indexed);
+  const gap = Math.max(5, Math.min(settings.imageGap || 10, 16));
+  const itemHeight = Math.max(44, 34 + gap);
+  const totalHeight = indexed.length * itemHeight + Math.max(0, indexed.length - 1) * gap;
+  const pad = Math.max(8, Math.round(gap / 2));
+
+  return `<section class="matching-page eng-kor-matching-page">
+    ${await generateHeader(title)}
+    <div class="matching-page-label">Page ${pageIndex + 1} of ${pageCount}</div>
+    <div class="matching-board" style="min-width:700px;">
+      <div class="matching-column" style="width:40%;min-height:${totalHeight}px;gap:${gap}px;">
+        ${indexed.map(pair => `<div class="matching-row" style="justify-content:flex-end;gap:12px;height:${itemHeight}px;">
+          <div class="matching-card word-cell" data-index="${pair.globalIndex}" data-lang="eng" style="padding:${pad}px 14px;background:#f8f9fa;font-weight:600;cursor:pointer;">${pair.eng || pair._originalEng || 'word'}</div>
+          <div class="matching-dot"></div>
+        </div>`).join('')}
+      </div>
+      <div class="matching-centre" style="width:20%;min-height:${totalHeight}px;">Draw lines<br>to connect</div>
+      <div class="matching-column" style="width:40%;min-height:${totalHeight}px;gap:${gap}px;">
+        ${korean.map(pair => `<div class="matching-row" style="justify-content:flex-start;gap:12px;height:${itemHeight}px;">
+          <div class="matching-dot"></div>
+          <div class="matching-card word-cell" data-index="${pair.globalIndex}" data-lang="kor" style="padding:${pad}px 14px;background:#fff5f5;border-color:#fed7d7;font-weight:600;cursor:pointer;">${pair.kor || 'word'}</div>
+        </div>`).join('')}
+      </div>
+    </div>
+  </section>`;
+}
+
+export async function generateMatchingWorksheetHTML({ layout, title, wordPairs, settings, renderImage, getImageUrl, generateHeader }) {
+  const perPage = layout === 'picture-matching' ? 8 : 10;
+  const pages = chunk(wordPairs, perPage);
+  const rendered = [];
+
+  for (let pageIndex = 0; pageIndex < pages.length; pageIndex += 1) {
+    const pagePairs = pages[pageIndex];
+    const offset = pageIndex * perPage;
+    if (layout === 'picture-matching') {
+      rendered.push(await renderPicturePage(pagePairs, pageIndex, pages.length, settings, renderImage, getImageUrl, generateHeader, title, offset));
+    } else {
+      rendered.push(await renderLanguagePage(pagePairs, pageIndex, pages.length, settings, generateHeader, title, offset));
+    }
+  }
+
+  return `<div class="worksheet-preview matching-pages" style="font-family:${settings.font};font-size:${settings.fontSize}px;line-height:1.5;">
+    ${pageCss()}
+    ${rendered.join('')}
+  </div>`;
+}

--- a/Teachers/tools/wordtest/preview.js
+++ b/Teachers/tools/wordtest/preview.js
@@ -2,15 +2,17 @@ import { state } from './state.js';
 import { enableImageDragAndDrop, renderImage, getImageUrl, getPlaceholderImage } from './images.js';
 import { hideRandomLetters } from './behaviors.js';
 import { generateWorksheetHTML as rendererGenerateWorksheetHTML } from './renderer.js';
+import { generateMatchingWorksheetHTML } from './matching-renderer.js';
 
 const currentWords = state.currentWords;
 const currentSettings = state.currentSettings;
+const MATCHING_LAYOUTS = ['picture-matching', 'eng-kor-matching'];
+const IMAGE_LAYOUTS = ['picture-list','picture-list-2col','picture-quiz','picture-quiz-5col','picture-matching','6col-images','5col-images','eng-kor-matching'];
 
 export async function updatePreview() {
-    // Keep a lightweight global mirror for UI-driven inline updates
     window.currentSettings = state.currentSettings;
     const previewArea = document.getElementById('previewArea');
-    const title = document.getElementById('titleInput').value || 'Worksheet Title';
+    const title = document.getElementById('titleInput')?.value || 'Worksheet Title';
     if (!previewArea) return;
 
     if (currentWords.length === 0) {
@@ -18,14 +20,12 @@ export async function updatePreview() {
         return;
     }
 
-    const imageBasedLayouts = ['picture-list','picture-list-2col','picture-quiz','picture-quiz-5col','picture-matching','6col-images','5col-images','eng-kor-matching'];
-    if (imageBasedLayouts.includes(currentSettings.layout)) {
-        previewArea.innerHTML = '<div class="preview-placeholder"><p>Loading images...</p></div>';
-        await new Promise(r => setTimeout(r, 100));
+    if (IMAGE_LAYOUTS.includes(currentSettings.layout)) {
+        previewArea.innerHTML = '<div class="preview-placeholder"><p>Loading worksheet...</p></div>';
+        await new Promise(resolve => setTimeout(resolve, 60));
     }
 
-    const worksheetHTML = await generateWorksheetHTML(title, currentWords);
-    previewArea.innerHTML = worksheetHTML;
+    previewArea.innerHTML = await generateWorksheetHTML(title, currentWords);
     ensurePreviewHint(previewArea);
     enableImageDragAndDrop(updatePreview);
     addWordCellInteractivity(previewArea);
@@ -33,7 +33,7 @@ export async function updatePreview() {
 
 export async function updatePreviewPreservingImages() {
     const previewArea = document.getElementById('previewArea');
-    const title = document.getElementById('titleInput').value || 'Worksheet Title';
+    const title = document.getElementById('titleInput')?.value || 'Worksheet Title';
     if (!previewArea) return;
 
     if (currentWords.length === 0) {
@@ -41,271 +41,201 @@ export async function updatePreviewPreservingImages() {
         return;
     }
 
-    // Preserve by (word,index) from the drop-zone dataset (not from <img>)
     const existingImages = new Map();
     previewArea.querySelectorAll('.image-drop-zone').forEach(zone => {
         const word = zone.getAttribute('data-word');
-        const idx = zone.getAttribute('data-index');
-        const img = zone.querySelector('img');
-        if (!word || idx === null || idx === undefined || !img) return;
-        const key = `${String(word).toLowerCase()}_${String(idx)}`;
-        existingImages.set(key, img.src);
+        const index = zone.getAttribute('data-index');
+        const image = zone.querySelector('img');
+        if (word && index !== null && image) existingImages.set(`${word.toLowerCase()}_${index}`, image.src);
     });
 
-    const worksheetHTML = await generateWorksheetHTML(title, currentWords);
-    previewArea.innerHTML = worksheetHTML;
+    previewArea.innerHTML = await generateWorksheetHTML(title, currentWords);
     ensurePreviewHint(previewArea);
 
     previewArea.querySelectorAll('.image-drop-zone').forEach(zone => {
         const word = zone.getAttribute('data-word');
-        const idx = zone.getAttribute('data-index');
-        if (!word || idx === null || idx === undefined) return;
-        const key = `${String(word).toLowerCase()}_${String(idx)}`;
-        const img = zone.querySelector('img');
-        const saved = existingImages.get(key) || (window.savedImageData && window.savedImageData[key] && window.savedImageData[key].src);
-        if (img && saved) img.src = saved;
+        const index = zone.getAttribute('data-index');
+        const image = zone.querySelector('img');
+        if (!word || index === null || !image) return;
+        const key = `${word.toLowerCase()}_${index}`;
+        const saved = existingImages.get(key) || window.savedImageData?.[key]?.src;
+        if (saved) image.src = saved;
     });
 
     enableImageDragAndDrop(updatePreviewPreservingImages);
     addWordCellInteractivity(previewArea);
 }
 
-// Efficient preview update that preserves images or updates styles in place
 export async function updatePreviewStyles() {
     window.currentSettings = state.currentSettings;
     const previewArea = document.getElementById('previewArea');
     if (!previewArea) return;
 
-    // If no preview yet, render it fresh
     const previewRoot = previewArea.querySelector('.worksheet-preview');
-    if (!previewRoot) {
-        return updatePreview();
-    }
+    if (!previewRoot) return updatePreview();
 
-    // If test mode hides or masks text, rebuild while preserving images
-    if (currentSettings.testMode && currentSettings.testMode !== 'none') {
+    if ((currentSettings.testMode && currentSettings.testMode !== 'none') || IMAGE_LAYOUTS.includes(currentSettings.layout)) {
         return updatePreviewPreservingImages();
     }
 
-    // Certain layouts depend on gap/size for structure; rebuild to reflect changes
-    const imageBasedLayouts = ['picture-list','picture-list-2col','picture-quiz','picture-quiz-5col','picture-matching','6col-images','5col-images','eng-kor-matching'];
-    if (imageBasedLayouts.includes(currentSettings.layout)) {
-        return updatePreviewPreservingImages();
-    }
-
-    // Otherwise, update styles in place without regenerating HTML
     try {
         previewRoot.style.fontFamily = currentSettings.font;
-        previewRoot.style.fontSize = currentSettings.fontSize + 'px';
-
-        const tables = previewRoot.querySelectorAll('table');
-        tables.forEach(table => {
+        previewRoot.style.fontSize = `${currentSettings.fontSize}px`;
+        previewRoot.querySelectorAll('table').forEach(table => {
             table.style.fontFamily = currentSettings.font;
-            table.style.fontSize = currentSettings.fontSize + 'px';
+            table.style.fontSize = `${currentSettings.fontSize}px`;
         });
-
-        const textElements = previewRoot.querySelectorAll('th, td, div');
-        textElements.forEach(el => {
-            if (!el.classList.contains('image-drop-zone') && !el.querySelector('.image-drop-zone')) {
-                el.style.fontFamily = currentSettings.font;
+        previewRoot.querySelectorAll('th, td, div').forEach(element => {
+            if (!element.classList.contains('image-drop-zone') && !element.querySelector('.image-drop-zone')) {
+                element.style.fontFamily = currentSettings.font;
             }
         });
-
-        // Update image sizes only if not custom-resized
-        const images = previewRoot.querySelectorAll('.image-drop-zone img');
-        images.forEach(img => {
-            if (!img.hasAttribute('data-custom-size')) {
-                img.style.width = currentSettings.imageSize + 'px';
-                img.style.height = currentSettings.imageSize + 'px';
+        previewRoot.querySelectorAll('.image-drop-zone img').forEach(image => {
+            if (!image.hasAttribute('data-custom-size')) {
+                image.style.width = `${currentSettings.imageSize}px`;
+                image.style.height = `${currentSettings.imageSize}px`;
             }
         });
-
-        // Update emoji placeholders (font-size based)
-        const emojiEls = previewRoot.querySelectorAll('.image-drop-zone div[style*="font-size"]');
-        emojiEls.forEach(el => {
-            el.style.fontSize = Math.round(currentSettings.imageSize * 0.8) + 'px';
+        previewRoot.querySelectorAll('.image-drop-zone div[style*="font-size"]').forEach(element => {
+            element.style.fontSize = `${Math.round(currentSettings.imageSize * 0.8)}px`;
         });
-
-        // Update generic placeholders with width/height inline styles
-        const placeholders = previewRoot.querySelectorAll('.image-drop-zone div[style*="width"]');
-        placeholders.forEach(el => {
-            if (!el.style.fontSize) {
-                el.style.width = currentSettings.imageSize + 'px';
-                el.style.height = currentSettings.imageSize + 'px';
+        previewRoot.querySelectorAll('.image-drop-zone div[style*="width"]').forEach(element => {
+            if (!element.style.fontSize) {
+                element.style.width = `${currentSettings.imageSize}px`;
+                element.style.height = `${currentSettings.imageSize}px`;
             }
         });
-    } catch (e) {
-        console.warn('updatePreviewStyles fallback due to error:', e);
+    } catch (error) {
+        console.warn('updatePreviewStyles fallback due to error:', error);
         return updatePreviewPreservingImages();
     }
 }
 
-// Helper overlay: show once per session for ~4s and do not reappear
 function ensurePreviewHint(previewArea) {
-    if (!previewArea) return;
-    const onceKey = 'waPreviewHintShown';
-    if (sessionStorage.getItem(onceKey) === '1') return;
+    if (!previewArea || sessionStorage.getItem('waPreviewHintShown') === '1') return;
+    if (window.getComputedStyle(previewArea).position === 'static') previewArea.style.position = 'relative';
 
-    // Make container relative for absolute overlay
-    const cs = window.getComputedStyle(previewArea);
-    if (cs.position === 'static') {
-        previewArea.style.position = 'relative';
-    }
-
-    let hint = previewArea.querySelector('#preview-helper-hint');
-    if (!hint) {
-        hint = document.createElement('div');
-        hint.id = 'preview-helper-hint';
-        hint.className = 'print-hide';
-        hint.textContent = 'Tip: Left-click a word to edit, right-click to delete';
-        hint.style.position = 'absolute';
-        hint.style.left = '8px';
-        hint.style.top = '8px';
-        hint.style.background = 'rgba(36, 159, 230, 0.9)';
-        hint.style.color = '#fff';
-        hint.style.padding = '6px 10px';
-        hint.style.borderRadius = '6px';
-        hint.style.fontSize = '12px';
-        hint.style.zIndex = '20';
-        hint.style.opacity = '0';
-        hint.style.pointerEvents = 'none';
-        hint.style.transition = 'opacity .18s cubic-bezier(.4,0,.2,1)';
-        previewArea.appendChild(hint);
-    }
-
-    // Show once
+    const hint = document.createElement('div');
+    hint.id = 'preview-helper-hint';
+    hint.className = 'print-hide';
+    hint.textContent = 'Tip: Left-click a word to edit, right-click to delete';
+    Object.assign(hint.style, {
+        position: 'absolute', left: '8px', top: '8px', background: 'rgba(36,159,230,.9)', color: '#fff',
+        padding: '6px 10px', borderRadius: '6px', fontSize: '12px', zIndex: '20', opacity: '0',
+        pointerEvents: 'none', transition: 'opacity .18s cubic-bezier(.4,0,.2,1)'
+    });
+    previewArea.appendChild(hint);
     requestAnimationFrame(() => {
         hint.style.opacity = '1';
         setTimeout(() => {
             hint.style.opacity = '0';
-            sessionStorage.setItem(onceKey, '1');
+            sessionStorage.setItem('waPreviewHintShown', '1');
         }, 4000);
     });
 }
 
-// Add interactive editing and deletion to word cells in the preview
 function addWordCellInteractivity(previewArea) {
-    if (!previewArea) return;
-    const cw = currentWords;
+    if (!previewArea || previewArea.dataset.wordCellHandlers === '1') return;
+    previewArea.dataset.wordCellHandlers = '1';
 
-    function isDuplicateEng(eng) {
-        const v = (eng || '').trim().toLowerCase();
-        if (!v) return false;
-        let count = 0;
-        for (const w of cw) if (w.eng && w.eng.trim().toLowerCase() === v) count++;
-        return count > 1;
-    }
-    function isDuplicateKor(kor) {
-        const v = (kor || '').trim().toLowerCase();
-        if (!v) return false;
-        let count = 0;
-        for (const w of cw) if (w.kor && w.kor.trim().toLowerCase() === v) count++;
-        return count > 1;
-    }
+    const countDuplicates = (language, value) => {
+        const normalised = (value || '').trim().toLowerCase();
+        return normalised && currentWords.filter(word => (word[language] || '').trim().toLowerCase() === normalised).length > 1;
+    };
 
-    // Remove any previous inline handlers
-    previewArea.oncontextmenu = null;
-    previewArea.onclick = null;
-
-    // Right-click: delete word
-    previewArea.addEventListener('contextmenu', (e) => {
-        const cell = e.target.closest('.word-cell');
-        if (cell && previewArea.contains(cell)) {
-            e.preventDefault();
-            const idx = parseInt(cell.getAttribute('data-index'));
-            if (isNaN(idx)) return;
-            // Undo snapshot
-            state.undoStack.push(JSON.parse(JSON.stringify(cw)));
-            if (state.undoStack.length > 50) state.undoStack.shift();
-            // Delete
-            cw.splice(idx, 1);
-            // Sync textarea
-            const ta = document.getElementById('wordListTextarea');
-            if (ta) ta.value = cw.map(w => `${w.eng}, ${w.kor}`).join('\n');
-            // Re-render preserving images
-            updatePreviewPreservingImages();
-        }
+    previewArea.addEventListener('contextmenu', event => {
+        const cell = event.target.closest('.word-cell');
+        if (!cell || !previewArea.contains(cell)) return;
+        event.preventDefault();
+        const index = Number.parseInt(cell.dataset.index, 10);
+        if (!Number.isInteger(index) || !currentWords[index]) return;
+        state.undoStack.push(JSON.parse(JSON.stringify(currentWords)));
+        if (state.undoStack.length > 50) state.undoStack.shift();
+        currentWords.splice(index, 1);
+        syncTextarea();
+        updatePreviewPreservingImages();
     });
 
-    // Left-click: inline edit
-    previewArea.addEventListener('click', (e) => {
-        if (e.button !== 0) return;
-        const cell = e.target.closest('.word-cell');
-        if (!cell || !previewArea.contains(cell)) return;
-        if (cell.querySelector('input')) return;
-        const idx = parseInt(cell.getAttribute('data-index'));
-        const lang = cell.getAttribute('data-lang');
-        if (isNaN(idx) || !lang) return;
+    previewArea.addEventListener('click', event => {
+        if (event.button !== 0) return;
+        const cell = event.target.closest('.word-cell');
+        if (!cell || !previewArea.contains(cell) || cell.querySelector('input')) return;
+        const index = Number.parseInt(cell.dataset.index, 10);
+        const language = cell.dataset.lang;
+        if (!Number.isInteger(index) || !currentWords[index] || !['eng', 'kor'].includes(language)) return;
 
-        const currentVal = (cw[idx] && cw[idx][lang]) || '';
+        const originalValue = currentWords[index][language] || '';
         const input = document.createElement('input');
         input.type = 'text';
-        input.value = currentVal;
-        input.style.width = '90%';
-        input.style.background = 'transparent';
-        input.style.border = '1px solid #ccc';
-        input.style.fontSize = 'inherit';
-        input.style.fontFamily = 'inherit';
-        cell.innerHTML = '';
-        cell.appendChild(input);
+        input.value = originalValue;
+        Object.assign(input.style, { width: '90%', background: 'transparent', border: '1px solid #ccc', fontSize: 'inherit', fontFamily: 'inherit' });
+        cell.replaceChildren(input);
         input.focus();
 
-        const saveEdit = () => {
-            state.undoStack.push(JSON.parse(JSON.stringify(cw)));
-            if (state.undoStack.length > 50) state.undoStack.shift();
-            cw[idx][lang] = input.value.trim();
-            const ta = document.getElementById('wordListTextarea');
-            if (ta) ta.value = cw.map(w => `${w.eng}, ${w.kor}`).join('\n');
-            const isDup = lang === 'eng' ? isDuplicateEng(input.value.trim()) : isDuplicateKor(input.value.trim());
-            const content = input.value.trim() || '______';
-            const overlay = isDup ? '<span class="dup-overlay-screen" style="position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(255,140,0,0.25);pointer-events:none;z-index:1;"></span>' : '';
-            const highlighted = `<span style="position:relative;display:inline-block;width:100%;">${overlay}<span style="position:relative;z-index:2;">${content}</span></span>`;
-            cell.innerHTML = highlighted;
+        let completed = false;
+        const finish = save => {
+            if (completed) return;
+            completed = true;
+            if (save) {
+                state.undoStack.push(JSON.parse(JSON.stringify(currentWords)));
+                if (state.undoStack.length > 50) state.undoStack.shift();
+                currentWords[index][language] = input.value.trim();
+                syncTextarea();
+            }
+            const value = save ? currentWords[index][language] : originalValue;
+            const duplicate = countDuplicates(language, value);
+            cell.innerHTML = `${duplicate ? '<span class="dup-overlay-screen" style="position:absolute;inset:0;background:rgba(255,140,0,.25);pointer-events:none;z-index:1;"></span>' : ''}<span style="position:relative;z-index:2;">${value || '______'}</span>`;
         };
-        const cancelEdit = () => {
-            const originalValue = cw[idx][lang] || '______';
-            const isDup = lang === 'eng' ? isDuplicateEng(originalValue) : isDuplicateKor(originalValue);
-            const overlay = isDup ? '<span class="dup-overlay-screen" style="position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(255,140,0,0.25);pointer-events:none;z-index:1;"></span>' : '';
-            const highlighted = `<span style=\"position:relative;display:inline-block;width:100%;\">${overlay}<span style=\"position:relative;z-index:2;\">${originalValue}</span></span>`;
-            cell.innerHTML = highlighted;
-        };
-        input.addEventListener('blur', saveEdit);
-        input.addEventListener('keydown', (e2) => {
-            if (e2.key === 'Enter') saveEdit();
-            else if (e2.key === 'Escape') cancelEdit();
+
+        input.addEventListener('blur', () => finish(true));
+        input.addEventListener('keydown', keyEvent => {
+            if (keyEvent.key === 'Enter') finish(true);
+            if (keyEvent.key === 'Escape') finish(false);
         });
     });
 }
 
+function syncTextarea() {
+    const textarea = document.getElementById('wordListTextarea');
+    if (textarea) textarea.value = currentWords.map(word => `${word.eng}, ${word.kor}`).join('\n');
+}
+
 export async function generateWorksheetHTML(title, wordPairs) {
-    // Minimal header generator to keep renderer decoupled
-    const generateWorksheetHeader = async (hdrTitle) => {
-        const safeTitle = (hdrTitle || '').toString();
-        // Resolve logo to an absolute URL for reliability in preview/print
-        let logoSrc = '';
-        try {
-            logoSrc = new URL('../../../Assets/Images/color-logo1.png', window.location.href).href;
-        } catch (_) {
-            logoSrc = '../../../Assets/Images/color-logo1.png';
-        }
-        return `
-            <div class="worksheet-header" style="margin-bottom: 12px;">
-                <div style="display:flex;align-items:center;gap:12px;">
-                    <img src="${logoSrc}" alt="Willena" style="height:70px;width:auto;display:block;" class="worksheet-logo" />
-                    <h2 class="title" style="margin:0;font-family:${currentSettings.font};font-size:${Math.max(18, currentSettings.fontSize + 6)}px;">${safeTitle}</h2>
-                </div>
-                <div class="worksheet-header-fields" style="display:flex;gap:32px;margin-top:8px;align-items:center;">
-                    <div style="font-size:15px;font-family:${currentSettings.font};color:#444;">
-                        Name: <span style="display:inline-block;min-width:120px;border-bottom:1px solid #bbb;">&nbsp;</span>
-                    </div>
-                    <div style="font-size:15px;font-family:${currentSettings.font};color:#444;">
-                        Date: <span style="display:inline-block;min-width:100px;border-bottom:1px solid #bbb;">&nbsp;</span>
-                    </div>
-                </div>
+    const generateWorksheetHeader = async headerTitle => {
+        let logoSrc;
+        try { logoSrc = new URL('../../../Assets/Images/color-logo1.png', window.location.href).href; }
+        catch (_) { logoSrc = '../../../Assets/Images/color-logo1.png'; }
+        return `<div class="worksheet-header" style="margin-bottom:12px;">
+            <div style="display:flex;align-items:center;gap:12px;">
+                <img src="${logoSrc}" alt="Willena" style="height:70px;width:auto;display:block;" class="worksheet-logo">
+                <h2 class="title" style="margin:0;font-family:${currentSettings.font};font-size:${Math.max(18, currentSettings.fontSize + 6)}px;">${String(headerTitle || '')}</h2>
             </div>
-        `;
+            <div class="worksheet-header-fields" style="display:flex;gap:32px;margin-top:8px;align-items:center;">
+                <div style="font-size:15px;font-family:${currentSettings.font};color:#444;">Name: <span style="display:inline-block;min-width:120px;border-bottom:1px solid #bbb;">&nbsp;</span></div>
+                <div style="font-size:15px;font-family:${currentSettings.font};color:#444;">Date: <span style="display:inline-block;min-width:100px;border-bottom:1px solid #bbb;">&nbsp;</span></div>
+            </div>
+        </div>`;
     };
-    return await rendererGenerateWorksheetHTML(
+
+    if (MATCHING_LAYOUTS.includes(currentSettings.layout)) {
+        const maskedPairs = wordPairs.map(pair => {
+            if (currentSettings.testMode === 'hide-eng') return { eng: '', kor: pair.kor, _originalEng: pair.eng };
+            if (currentSettings.testMode === 'hide-kor') return { eng: pair.eng, kor: '', _originalEng: pair.eng };
+            if (currentSettings.testMode === 'hide-all') return { eng: '', kor: '', _originalEng: pair.eng };
+            return { eng: pair.eng, kor: pair.kor, _originalEng: pair.eng };
+        });
+        return generateMatchingWorksheetHTML({
+            layout: currentSettings.layout,
+            title,
+            wordPairs: maskedPairs,
+            settings: currentSettings,
+            renderImage,
+            getImageUrl,
+            generateHeader: generateWorksheetHeader
+        });
+    }
+
+    return rendererGenerateWorksheetHTML(
         title,
         wordPairs,
         currentSettings,


### PR DESCRIPTION
Improves the two matching layouts while leaving all other Word Builder layouts on the existing renderer.

Changes:
- Picture Matching now uses every word and creates a new page after each group of 8.
- English–Korean Matching now uses every word and creates a new page after each group of 10.
- Each page has a visible A4 preview, page number, repeated worksheet header and explicit print page break.
- Word editing and deletion continue to use the original global word indexes across pages.
- The feature is isolated in matching-renderer.js for easy rollback.

Rollback point: rollback/matching-before-pagination