### PR TITLE
Allow student progress refresh without Origin header

### DIFF
--- a/cloudflare-workers/progress-summary/src/refresh-index.js
+++ b/cloudflare-workers/progress-summary/src/refresh-index.js
@@ -1,6 +1,5 @@
 import baseWorker from './index.js';
 
-const STUDENT_ORIGIN = 'https://students.willenaenglish.com';
 const COOKIE_DOMAIN = '.willenaenglish.com';
 
 function parseCookies(header) {
@@ -69,7 +68,7 @@ export default {
   async fetch(request, env, ctx) {
     const firstRequest = preferCookieRequest(request);
     const first = await baseWorker.fetch(firstRequest, env, ctx);
-    if (first.status !== 401 || request.headers.get('Origin') !== STUDENT_ORIGIN) {
+    if (first.status !== 401) {
       return first;
     }
 


### PR DESCRIPTION
Removes the Origin-header requirement from the progress-summary refresh wrapper. Same-origin GET requests may omit Origin, which prevented expired student sessions from being repaired for points and stars. Refresh still only occurs after a 401 and only when a valid refresh cookie is present.