### PR TITLE
Fix teacher login redirect check

### DIFF
--- a/Teachers/auth-refresh.js
+++ b/Teachers/auth-refresh.js
@@ -28,9 +28,9 @@ async function sessionRequest() {
 
 function redirectAuthenticatedLogin(data) {
   if (!/\/Teachers\/(?:login|signin)\.html$/i.test(window.location.pathname)) return;
-
-  const role = String(data?.role || '').toLowerCase();
-  if (!['teacher', 'admin'].includes(role)) return;
+  // whoami_teacher is already restricted to teacher/admin accounts, so a
+  // successful response is sufficient even when the response omits `role`.
+  if (!data?.success) return;
 
   const params = new URLSearchParams(window.location.search);
   const requested = params.get('redirect');


### PR DESCRIPTION
Removes the unnecessary role-field requirement from the login-page redirect. The whoami_teacher endpoint is already teacher/admin-only, so any successful response should redirect to the teacher dashboard.