### PR TITLE
Fix level-test report sentence scoring consistency

### DIFF
--- a/free-level-test/admin-report-v2/index.html
+++ b/free-level-test/admin-report-v2/index.html
@@ -8,7 +8,7 @@
 <meta http-equiv="Pragma" content="no-cache">
 <meta http-equiv="Expires" content="0">
 <title>Willena English Student Report</title>
-<link rel="icon" href="/Assets/Images/Logo.png?v=20260806-score1">
+<link rel="icon" href="/Assets/Images/Logo.png?v=20260806-score2">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700;800&family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -45,7 +45,7 @@
 <body>
 <div class="app-shell">
 <header class="app-header">
-<img src="/Assets/Images/Logo.png?v=20260806-score1" alt="Willena English" class="brand-logo">
+<img src="/Assets/Images/Logo.png?v=20260806-score2" alt="Willena English" class="brand-logo">
 <div class="brand-copy"><strong>Willena English</strong><span id="brandSubtitle">학생 리포트</span></div>
 <div class="language-segmented" role="group" aria-label="Language">
 <button type="button" data-language-choice="ko" class="is-active">한국어</button>
@@ -55,9 +55,9 @@
 <main id="app" class="app-main" aria-live="polite"><section class="screen shared-report-loading">보고서를 불러오는 중입니다…</section></main>
 <footer id="footerText">Willena English · Student Report</footer>
 </div>
-<script src="../js/canonical-answer-scoring.js?v=20260806-score1"></script>
-<script src="../admin-report/shared-report.js?v=20260806-score1"></script>
-<script src="../admin-report/stored-level-authority.js?v=20260806-score1"></script>
+<script src="../js/canonical-answer-scoring.js?v=20260806-score2"></script>
+<script src="../admin-report/shared-report.js?v=20260806-score2"></script>
+<script src="../admin-report/stored-level-authority.js?v=20260806-score2"></script>
 <script src="../js/segmented-skill-report.js?v=20260803-safe2"></script>
 <script src="../js/responsive-report-journey.js?v=20260803-safe2"></script>
 <script src="../js/report-level-guide.js?v=20260803-full1"></script>

--- a/free-level-test/index.html
+++ b/free-level-test/index.html
@@ -50,8 +50,8 @@
 <script src="./js/dialogue-tts.js?v=20260730-3"></script>
 <script src="./js/adaptive-calibration-loader.js?v=20260801-2"></script>
 <script src="./js/level-result-consistency.js?v=20260803-5"></script>
-<script src="./js/canonical-answer-scoring.js?v=20260806-1"></script>
-<script src="./js/test-recording.js?v=20260806-1"></script>
+<script src="./js/canonical-answer-scoring.js?v=20260806-score2"></script>
+<script src="./js/test-recording.js?v=20260806-score2"></script>
 <script src="./js/scramble-token-letter-fix.js?v=20260801-1"></script>
 <script src="./js/loading-transitions.js?v=20260731-2"></script>
 <script src="./js/listening-audio-webview.js?v=20260731-1"></script>

--- a/free-level-test/js/canonical-answer-scoring.js
+++ b/free-level-test/js/canonical-answer-scoring.js
@@ -12,7 +12,7 @@
     var text = Array.isArray(value) ? value.map(cleanText).join(' ') : cleanText(value);
     return text
       .toLocaleLowerCase('en-US')
-      .replace(/[.,!?;:。！？、，；：]/gu, '')
+      .replace(/[.,!?;:。！？、，；：]+$/gu, '')
       .replace(/\s+/g, ' ')
       .trim();
   }
@@ -29,22 +29,39 @@
     return JSON.stringify(exactComparable(selected)) === JSON.stringify(exactComparable(correct));
   }
 
+  function firstDefined(row, keys) {
+    for (var index = 0; index < keys.length; index += 1) {
+      if (row[keys[index]] !== undefined && row[keys[index]] !== null) return row[keys[index]];
+    }
+    return undefined;
+  }
+
   function repairResponse(row) {
     if (!row || typeof row !== 'object') return row;
-    var type = row.question_type || row.item_type || row.type;
-    var selected = row.selected_answer !== undefined ? row.selected_answer : row.selected;
-    var correct = row.correct_answer !== undefined ? row.correct_answer : row.answer;
-    if (selected === undefined || correct === undefined) return row;
-    row.is_correct = isCorrect(type, selected, correct);
-    if ('correct' in row) row.correct = row.is_correct;
+    var type = firstDefined(row, ['question_type', 'item_type', 'type']);
+    var selected = firstDefined(row, ['selected_answer', 'student_answer', 'selected', 'response']);
+    var correct = firstDefined(row, ['correct_answer', 'answer', 'expected_answer']);
+
+    if (type !== 'sentence_unscramble' || selected === undefined || correct === undefined) return row;
+
+    var corrected = isCorrect(type, selected, correct);
+    row.is_correct = corrected;
+    if ('correct' in row) row.correct = corrected;
+    if ('isCorrect' in row) row.isCorrect = corrected;
     return row;
+  }
+
+  function repairList(rows) {
+    if (Array.isArray(rows)) rows.forEach(repairResponse);
   }
 
   function repairPayload(payload) {
     if (!payload || typeof payload !== 'object') return payload;
-    if (Array.isArray(payload.responses)) payload.responses.forEach(repairResponse);
-    if (Array.isArray(payload.answers)) payload.answers.forEach(repairResponse);
-    if (payload.attempt && Array.isArray(payload.attempt.responses)) payload.attempt.responses.forEach(repairResponse);
+    repairList(payload.responses);
+    repairList(payload.answers);
+    repairList(payload.question_results);
+    repairList(payload.attempt && payload.attempt.responses);
+    repairList(payload.report && payload.report.responses);
     return payload;
   }
 


### PR DESCRIPTION
## What changed
- Use one canonical sentence-unscramble comparison in both the level test and teacher report.
- Ignore capitalization, trailing punctuation, Unicode-width differences, and repeated spaces while preserving word order.
- Repair legacy report response shapes before the teacher report estimates skill levels.
- Cache-bust the shared scoring script in both report entry points.

## Cases fixed
- `students must follow the rules` = `Students must follow the rules.`
- `she wears glasses` = `She wears glasses.`
- `are there any students in the yard` = `Are there any students in the yard?`

This also makes existing stored attempts display correctly when their raw selected and correct answers are available, without changing the saved answers.